### PR TITLE
Allow setting imagePullSecrets

### DIFF
--- a/templates/rethinkdb-cluster-stateful-set.yaml
+++ b/templates/rethinkdb-cluster-stateful-set.yaml
@@ -29,6 +29,10 @@ spec:
 {{ toYaml .Values.cluster.podAnnotations | indent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "rethinkdb.serviceAccountName" . }}
       containers:
         - name: {{ template "rethinkdb.name" . }}-cluster
@@ -70,7 +74,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
           livenessProbe:
-{{ toYaml .Values.cluster.livenessProbe | indent 12 }}          
+{{ toYaml .Values.cluster.livenessProbe | indent 12 }}
           readinessProbe:
 {{ toYaml .Values.cluster.readinessProbe | indent 12 }}
             exec:

--- a/templates/rethinkdb-proxy-deployment.yaml
+++ b/templates/rethinkdb-proxy-deployment.yaml
@@ -28,6 +28,10 @@ spec:
 {{ toYaml .Values.proxy.podAnnotations | indent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "rethinkdb.serviceAccountName" . }}
       containers:
         - name: {{ template "rethinkdb.name" . }}-proxy

--- a/values.yaml
+++ b/values.yaml
@@ -4,6 +4,8 @@ image:
   tag: v2.4.1
   pullPolicy: IfNotPresent
 
+imagePullSecrets: []
+
 # RethinkDB Cluster Config
 cluster:
   replicas: 3


### PR DESCRIPTION
Nowadays the Docker.com registry has a rate limit which can be really annoying and setting the `imagePullSecrets` on the `StatefullSet` and the `Deployment` solves it.