### PR TITLE
Upgrades RethinkDB to version 2.4.2

### DIFF
--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Versions
-ARG UPSTREAM_IMAGE=rethinkdb:2.4.1
+ARG UPSTREAM_IMAGE=rethinkdb:2.4.2
 
 FROM golang:1.16 AS builder
 


### PR DESCRIPTION
This commit upgrades RethinkDB to the recently released version 2.4.2.